### PR TITLE
Updating package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "BSD-2-Clause",
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": ">=0.12.0 <=0.14.0"
   },
   "dependencies": {
     "browserify": "^8.0.3",


### PR DESCRIPTION
Updating package.json file to support peerDependency of React up to 0.13.x

Have tested this in my own local project running React 0.13.3, and have had no issues thus far... Looking through the index.js file, I don't see anything that should conflict with 0.13.x in its current state, you're already using .render() vs .renderComponent(), and .createFactory() where applicable.
